### PR TITLE
migration - disable querylog to avoid exhausted memory

### DIFF
--- a/src/migrations/2014_11_20_110626_create_laravel_ipcountry_table.php
+++ b/src/migrations/2014_11_20_110626_create_laravel_ipcountry_table.php
@@ -13,6 +13,8 @@ class CreateLaravelIpCountryTable extends Migration {
 	public function up()
 	{
 		//
+        DB::disableQueryLog();
+
         Schema::dropIfExists('laravel_ip2country');
 
         Schema::create('laravel_ip2country', function($table)


### PR DESCRIPTION
I was executing the migration that creates and filles the ip2country, but it got interrupted due to a memory exhausted error. I disabled the query log to avoid this error.